### PR TITLE
fix: Deno.transpileOnly is being replaced by Deno.emit

### DIFF
--- a/src/rollup-plugin-deno-resolver/denoResolver.ts
+++ b/src/rollup-plugin-deno-resolver/denoResolver.ts
@@ -46,8 +46,6 @@ export function denoResolver(
         return null;
       }
 
-      const code = await loadUrl(url, fetchOpts);
-
       if (isTypescript(url.href)) {
         const outputUrlHref = url.href + ".js";
         const { files: { [outputUrlHref]: output } } = await Deno.emit(

--- a/src/rollup-plugin-deno-resolver/denoResolver.ts
+++ b/src/rollup-plugin-deno-resolver/denoResolver.ts
@@ -58,6 +58,8 @@ export function denoResolver(
 
         return output;
       }
+      
+      const code = await loadUrl(url, fetchOpts);
 
       // TODO: URL import source maps not yet supported
       if (isUrl(source)) {

--- a/src/rollup-plugin-deno-resolver/denoResolver.ts
+++ b/src/rollup-plugin-deno-resolver/denoResolver.ts
@@ -40,7 +40,6 @@ export function denoResolver(
       return resolveId(source, importer);
     },
     async load(source: string, importer?: string) {
-      const id = resolveId(source, importer);
       const url = parse(source, importer);
 
       if (!url) {
@@ -50,12 +49,16 @@ export function denoResolver(
       const code = await loadUrl(url, fetchOpts);
 
       if (isTypescript(url.href)) {
-        const { [id]: { source } } = await Deno.transpileOnly(
-          { [id]: code },
-          compilerOpts,
+        const outputUrlHref = url.href + ".js";
+        const { files: { [outputUrlHref]: output } } = await Deno.emit(
+          url,
+          {
+            check: false,
+            compilerOptions: compilerOpts,
+          },
         );
 
-        return source;
+        return output;
       }
 
       // TODO: URL import source maps not yet supported

--- a/src/rollup-plugin-deno-resolver/denoResolver.ts
+++ b/src/rollup-plugin-deno-resolver/denoResolver.ts
@@ -58,7 +58,6 @@ export function denoResolver(
 
         return output;
       }
-      
       const code = await loadUrl(url, fetchOpts);
 
       // TODO: URL import source maps not yet supported


### PR DESCRIPTION
## Details

As Deno 1.7, Deno.compile, Deno.bundle, and Deno.transpileOnly is being combined to Deno.emit.
This PR implemenet Deno.emit in place of Deno.transpileOnly in denoResolver.ts.

I've tested it by bundling and running the example.

## CheckList

- [x] Has been tested (where required).
