### PR TITLE
[#10] Add `bundle.close()` to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ const options = {
 
 const bundle = await rollup(options);
 await bundle.write(options.output);
+await bundle.close();
 ```
 
 Or using the `watch` API:

--- a/example/rollup.build.ts
+++ b/example/rollup.build.ts
@@ -3,3 +3,4 @@ import options from "./rollup.config.ts";
 
 const bundle = await rollup(options);
 await bundle.write(options.output);
+await bundle.close();


### PR DESCRIPTION
# Issue

Fixes #10.

## Details

I did this with Github's online editor, which is rather basic, but I think you can squash the commits when merging.

I tested this in my own script. Didn't seem to make much difference, but as you say is better practice. :-)