### PR TITLE
[NO-ISSUE] Remove double resolving of source url from importer

### DIFF
--- a/src/rollup-plugin-deno-resolver/denoResolver.test.ts
+++ b/src/rollup-plugin-deno-resolver/denoResolver.test.ts
@@ -1,5 +1,4 @@
 import { expect } from "../../test/deps.ts";
-import { join, resolve } from "../../deps.ts";
 import { describe, it } from "../../test/mod.ts";
 import { denoResolver } from "./denoResolver.ts";
 

--- a/src/rollup-plugin-deno-resolver/denoResolver.ts
+++ b/src/rollup-plugin-deno-resolver/denoResolver.ts
@@ -1,7 +1,6 @@
 import type { Plugin } from "../../deps.ts";
 import { parse } from "./parse.ts";
 import { isTypescript } from "./isTypescript.ts";
-import { ensureUrl } from "./ensureUrl.ts";
 import { resolveId } from "./resolveId.ts";
 import { exists } from "./exists.ts";
 import { loadUrl } from "./loadUrl.ts";
@@ -40,7 +39,7 @@ export function denoResolver(
     name: "rollup-plugin-deno-resolver",
     async resolveId(source: string, importer?: string) {
       let id = resolveId(source, importer);
-      let url = parse(id, importer);
+      let url = parse(id);
 
       if (!url) {
         return handleUnresolvedId(id, importer);
@@ -56,13 +55,14 @@ export function denoResolver(
 
       if (!(await exists(url, fetchOpts))) {
         id = id.substr(0, id.length - 3);
+
         return handleUnresolvedId(id, importer);
       }
 
       return id;
     },
-    async load(source: string, importer?: string) {
-      const url = parse(source, importer);
+    async load(id: string) {
+      const url = parse(id);
 
       if (!url) {
         return null;

--- a/src/rollup-plugin-deno-resolver/getUrlBase.test.ts
+++ b/src/rollup-plugin-deno-resolver/getUrlBase.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "../../test/deps.ts";
-import { dirname, join, resolve, sep, toFileUrl } from "../../deps.ts";
+import { join, sep, toFileUrl } from "../../deps.ts";
 import { describe, it } from "../../test/mod.ts";
 import { getUrlBase } from "./getUrlBase.ts";
 
@@ -10,56 +10,9 @@ function assertUrlMatch(test: URL, expected: URL): void | never {
 }
 
 describe("getUrlBase", () => {
-  it("getUrlBase: when no importer is provided: should return the CWD as a file URL", () => {
+  it("getUrlBase: should return the CWD as a file URL", () => {
     const expected = toFileUrl(join(Deno.cwd(), sep));
     const urlBase = getUrlBase();
-
-    assertUrlMatch(urlBase, expected);
-  });
-
-  it("getUrlBase: when an undefined importer is provided: should return the CWD as a file URL", () => {
-    const expected = toFileUrl(join(Deno.cwd(), sep));
-    const urlBase = getUrlBase(undefined);
-
-    assertUrlMatch(urlBase, expected);
-  });
-
-  it("getUrlBase: when an absolute path importer is provided: should return the directory path of the importer as a file URL with no trailing slash", () => {
-    const importer = resolve("./getUrlBase.test.ts");
-    const expected = toFileUrl(dirname(importer));
-    const urlBase = getUrlBase(importer);
-
-    assertUrlMatch(urlBase, expected);
-  });
-
-  it("getUrlBase: when a remote URL path importer is provided: should return the directory path of the importer as a file URL", () => {
-    const importer = "https://github.com/cmorten/deno-rollup/test.ts";
-    const expected = new URL(join(dirname(importer), sep));
-    const urlBase = getUrlBase(importer);
-
-    assertUrlMatch(urlBase, expected);
-  });
-
-  it("getUrlBase: when an sibling relative path importer is provided: should return the directory path of the importer as a file URL with no trailing slash", () => {
-    const importer = "./test.ts";
-    const expected = toFileUrl(join(Deno.cwd(), dirname(importer)));
-    const urlBase = getUrlBase(importer);
-
-    assertUrlMatch(urlBase, expected);
-  });
-
-  it("getUrlBase: when a parent relative path importer is provided: should return the directory path of the importer as a file URL with no trailing slash", () => {
-    const importer = "../test.ts";
-    const expected = toFileUrl(join(Deno.cwd(), dirname(importer)));
-    const urlBase = getUrlBase(importer);
-
-    assertUrlMatch(urlBase, expected);
-  });
-
-  it("getUrlBase: when a child relative path importer is provided: should return the directory path of the importer as a file URL with no trailing slash", () => {
-    const importer = "./test-path/test.ts";
-    const expected = toFileUrl(join(Deno.cwd(), dirname(importer)));
-    const urlBase = getUrlBase(importer);
 
     assertUrlMatch(urlBase, expected);
   });

--- a/src/rollup-plugin-deno-resolver/getUrlBase.ts
+++ b/src/rollup-plugin-deno-resolver/getUrlBase.ts
@@ -1,29 +1,11 @@
-import { dirname, isAbsolute, join, sep, toFileUrl } from "../../deps.ts";
-import { ensureUrl } from "./ensureUrl.ts";
+import { join, sep, toFileUrl } from "../../deps.ts";
 
 /**
  * getUrlBase
  * 
- * @param {string} [importer] 
  * @returns {URL}
  * @private
  */
-export function getUrlBase(importer?: string): URL {
-  let path: string;
-
-  if (importer) {
-    const importerUrl = ensureUrl(importer);
-
-    if (importerUrl) {
-      return new URL(join(dirname(importerUrl), sep));
-    } else if (isAbsolute(importer)) {
-      path = dirname(importer);
-    } else {
-      path = dirname(join(Deno.cwd(), importer));
-    }
-  } else {
-    path = join(Deno.cwd(), sep);
-  }
-
-  return toFileUrl(path);
+export function getUrlBase(): URL {
+  return toFileUrl(join(Deno.cwd(), sep));
 }

--- a/src/rollup-plugin-deno-resolver/parse.test.ts
+++ b/src/rollup-plugin-deno-resolver/parse.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "../../test/deps.ts";
-import { dirname, join, sep, toFileUrl } from "../../deps.ts";
+import { join, sep, toFileUrl } from "../../deps.ts";
 import { describe, it } from "../../test/mod.ts";
 import { parse } from "./parse.ts";
 
@@ -16,7 +16,7 @@ describe("parse", () => {
     assertUrlMatch(parse(source) as URL, new URL(source));
   });
 
-  it("parse: when a relative source is provided: and no importer is provided: it should return the resolved source from the CWD as a URL instance", () => {
+  it("parse: when a relative source is provided: it should return the resolved source from the CWD as a URL instance", () => {
     const source = "./test-path/test.ts";
 
     assertUrlMatch(
@@ -25,17 +25,7 @@ describe("parse", () => {
     );
   });
 
-  it("parse: when a relative source is provided: and an importer is provided: it should return the resolved source from the importer as a URL instance", () => {
-    const source = "./test/test.ts";
-    const importer = "https://github.com/cmorten/deno-rollup/test.ts";
-
-    assertUrlMatch(
-      parse(source, importer) as URL,
-      new URL(source, join(dirname(importer), sep)),
-    );
-  });
-
-  it("parse: when a source and importer pair that cannot be parsed are provided: it should return null", () => {
-    expect(parse("", "https://://")).toBe(null);
+  it("parse: when a source that cannot be parsed is provided: it should return null", () => {
+    expect(parse("https://://")).toBe(null);
   });
 });

--- a/src/rollup-plugin-deno-resolver/parse.ts
+++ b/src/rollup-plugin-deno-resolver/parse.ts
@@ -3,25 +3,21 @@ import { getUrlBase } from "./getUrlBase.ts";
 /**
  * parse
  * 
- * @param {string} source 
- * @param {string} [importer] 
+ * @param {string} id
  * @returns {URL|null}
  * @private
  */
-export function parse(
-  source: string,
-  importer?: string,
-): URL | null {
+export function parse(id: string): URL | null {
   try {
-    return new URL(source);
+    return new URL(id);
   } catch {
     // Not a URL in it's own right, but may be
     // relative to an importer URL or the CWD.
   }
 
   try {
-    return new URL(source, getUrlBase(importer));
-  } catch (_) {
+    return new URL(id, getUrlBase());
+  } catch {
     return null;
   }
 }

--- a/src/rollup-plugin-deno-resolver/resolveId.test.ts
+++ b/src/rollup-plugin-deno-resolver/resolveId.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "../../test/deps.ts";
-import { join, resolve } from "../../deps.ts";
+import { join, resolve, sep } from "../../deps.ts";
 import { describe, it } from "../../test/mod.ts";
 import { resolveId } from "./resolveId.ts";
 
@@ -48,6 +48,11 @@ describe("resolveId", () => {
   it("resolveId: when a relative path source is provided: it should return the source unchanged", () => {
     const source = join("..", "test-path", "test.ts");
     expect(resolveId(source)).toBe(source);
+  });
+
+  it("resolveId: when an unnormalized relative path source is provided: it should return the normalized source", () => {
+    const source = `.${sep}${sep}test.ts`;
+    expect(resolveId(source)).toBe(`test.ts`);
   });
 
   it("resolveId: when a relative path source is provided: and an encapsulating relative path importer is provided: it should return the resolved relative path of the source from the importer", () => {

--- a/src/rollup-plugin-deno-resolver/resolveId.ts
+++ b/src/rollup-plugin-deno-resolver/resolveId.ts
@@ -1,4 +1,4 @@
-import { dirname, extname, join } from "../../deps.ts";
+import { dirname, join, normalize } from "../../deps.ts";
 import { ensureUrl } from "./ensureUrl.ts";
 
 /**
@@ -15,6 +15,8 @@ export function resolveId(source: string, importer?: string): string {
   if (sourceUrl) {
     return sourceUrl;
   }
+
+  source = normalize(source);
 
   if (importer) {
     const importerUrl = ensureUrl(importer);


### PR DESCRIPTION
# Issue

No issue.

## Details

`resolveId` resolves the `source` relative to the `importer` to produce an `id`. This `id` is used to generate a full URL (file or http) for the source. Before the code was generating this URL using the `id` relative to the `importer`, but this has been done already and so is unnecessary, and in some cases it was not being handled.

By removing this second resolution relative to the `importer` we can greater simplify the `parse` code flow, needing only to use the `id` and CWD as the sources of truth.

## CheckList

- [ ] PR starts with [#_ISSUE_ID_].
- [ ] Has been tested (where required).
