### PR TITLE
[#26] Open 'rollup' to set custom Deno.CompilerOptions

### DIFF
--- a/src/mergeOptions.ts
+++ b/src/mergeOptions.ts
@@ -219,6 +219,7 @@ function mergeInputOptions(
     strictDeprecations: getOption("strictDeprecations"),
     treeshake: getObjectOption(config, overrides, "treeshake"),
     watch: getWatch(config, overrides, "watch"),
+    denoResolver: getWatch(config, overrides, "denoResolver"),
   };
 
   warnUnknownOptions(

--- a/src/rollup/mod.ts
+++ b/src/rollup/mod.ts
@@ -12,6 +12,7 @@ import type {
   WarningHandlerWithDefault,
 } from "../../deps.ts";
 import { VERSION } from "../../deps.ts";
+import { DenoResolverOptions } from "../rollup-plugin-deno-resolver/denoResolver.ts";
 import { rollup } from "./rollup.ts";
 import { watch } from "./watch.ts";
 
@@ -188,6 +189,7 @@ export interface InputOptions {
   strictDeprecations?: boolean;
   treeshake?: boolean | TreeshakingOptions;
   watch?: WatcherOptions | false;
+  denoResolver?: DenoResolverOptions;
 }
 
 /**

--- a/src/rollup/mod.ts
+++ b/src/rollup/mod.ts
@@ -103,7 +103,6 @@ export type {
   RollupCache,
   RollupError,
   RollupLogProps,
-  RollupOptions,
   RollupOutput,
   RollupWarning,
   RollupWatcherEvent,
@@ -190,6 +189,14 @@ export interface InputOptions {
   treeshake?: boolean | TreeshakingOptions;
   watch?: WatcherOptions | false;
   denoResolver?: DenoResolverOptions;
+}
+
+/**
+ * @public
+ */
+export interface RollupOptions extends InputOptions {
+  // This is included for compatibility with config files but ignored by rollup.rollup
+  output?: OutputOptions | OutputOptions[];
 }
 
 /**

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -1,4 +1,4 @@
-import type { InputOptions, RollupBuild } from "./mod.ts";
+import type { RollupBuild, RollupOptions } from "./mod.ts";
 import { rollup as _rollup } from "../../deps.ts";
 import { write } from "./write.ts";
 import { generate } from "./generate.ts";
@@ -29,7 +29,7 @@ import { error } from "../error.ts";
  * @public
  */
 export async function rollup(
-  options: InputOptions,
+  options: RollupOptions,
 ): Promise<RollupBuild> {
   const denoResolverPlugin = denoResolver(options.denoResolver);
 

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -1,4 +1,4 @@
-import type { RollupBuild, RollupOptions } from "./mod.ts";
+import type { InputOptions, RollupBuild } from "./mod.ts";
 import { rollup as _rollup } from "../../deps.ts";
 import { write } from "./write.ts";
 import { generate } from "./generate.ts";
@@ -29,9 +29,9 @@ import { error } from "../error.ts";
  * @public
  */
 export async function rollup(
-  options: RollupOptions,
+  options: InputOptions,
 ): Promise<RollupBuild> {
-  const denoResolverPlugin = denoResolver();
+  const denoResolverPlugin = denoResolver(options.denoResolver);
 
   options = {
     ...options,


### PR DESCRIPTION
# Issue

Fixes #26.

## Details

Open 'rollup' to set custom Deno.CompilerOptions.

## CheckList

- [X] PR starts with [#_ISSUE_ID_].
- [X] Has been tested (where required).
