### PR TITLE
[NO-ISSUE] Support Deno 1.10.2

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## [2.50.5+0.18.0] - 31-05-2021
+
+- chore: support Deno 1.10.2 and std 0.97.0
+- feat: upgrade Rollup to 2.50.5
+
 ## [2.42.3+0.17.1] - 23-03-2021
 
 - [#29] Rollup deno compiler options (#30)

--- a/.github/workflows/publish-egg.yml
+++ b/.github/workflows/publish-egg.yml
@@ -11,8 +11,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: denolib/setup-deno@v2
         with:
-          deno-version: 1.8.2
-      - run: deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.3.5/eggs.ts
+          deno-version: 1.10.2
+      - run: deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.3.6/eggs.ts
       - run: |
           export PATH="/home/runner/.deno/bin:$PATH"
           eggs link ${NEST_LAND_KEY}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        deno-version: [1.8.2]
+        deno-version: [1.10.2]
 
     runs-on: ${{ matrix.os }}
 
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        deno-version: [1.8.2]
+        deno-version: [1.10.2]
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Next-generation ES module bundler for <a href="https://deno.land/">Deno</a> port
 </p>
 <p align="center">
    <a href="https://deno.land/x/drollup"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Flatest-version%2Fx%2Fdrollup%2Fmod.ts" alt="deno-rollup latest /x/ version" /></a>
-   <a href="https://github.com/denoland/deno/blob/main/Releases.md"><img src="https://img.shields.io/badge/deno-^1.8.2-brightgreen?logo=deno" alt="Minimum supported Deno version" /></a>
+   <a href="https://github.com/denoland/deno/blob/main/Releases.md"><img src="https://img.shields.io/badge/deno-^1.10.2-brightgreen?logo=deno" alt="Minimum supported Deno version" /></a>
    <a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/drollup/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fdep-count%2Fx%2Fdrollup%2Fmod.ts" alt="deno-rollup dependency count" /></a>
    <a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/drollup/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fupdates%2Fx%2Fdrollup%2Fmod.ts" alt="deno-rollup dependency outdatedness" /></a>
    <a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/drollup/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fcache-size%2Fx%2Fdrollup%2Fmod.ts" alt="deno-rollup cached size" /></a>
@@ -55,7 +55,7 @@ with an optional configuration file, or else through its
 To install the CLI run:
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.
@@ -80,7 +80,7 @@ rollup -c --watch
 You can import deno-rollup straight into your project to bundle your modules:
 
 ```ts
-import { rollup } from "https://deno.land/x/drollup@2.42.3+0.17.1/mod.ts";
+import { rollup } from "https://deno.land/x/drollup@2.50.5+0.18.0/mod.ts";
 
 const options = {
   input: "./mod.ts",
@@ -99,7 +99,7 @@ await bundle.close();
 Or using the `watch` API:
 
 ```ts
-import { watch } from "https://deno.land/x/drollup@2.42.3+0.17.1/mod.ts";
+import { watch } from "https://deno.land/x/drollup@2.50.5+0.18.0/mod.ts";
 
 const options = {
   input: "./src/mod.ts",
@@ -179,7 +179,7 @@ To run the [examples](./examples) you have a couple of options:
 1. Run the deno-rollup `helloDeno` example directly from the repository:
 
    ```console
-   deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/helloDeno/rollup.build.ts
+   deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/helloDeno/rollup.build.ts
    ```
 
    This will create a `./dist` directory with the bundled files in your current

--- a/deps.ts
+++ b/deps.ts
@@ -2,7 +2,7 @@
  * std
  */
 
- export {
+export {
   basename,
   dirname,
   extname,

--- a/deps.ts
+++ b/deps.ts
@@ -2,7 +2,7 @@
  * std
  */
 
-export {
+ export {
   basename,
   dirname,
   extname,
@@ -14,7 +14,7 @@ export {
   resolve,
   sep,
   toFileUrl,
-} from "https://deno.land/std@0.91.0/path/mod.ts";
+} from "https://deno.land/std@0.97.0/path/mod.ts";
 export {
   bold,
   cyan,
@@ -22,18 +22,18 @@ export {
   green,
   red,
   underline,
-} from "https://deno.land/std@0.91.0/fmt/colors.ts";
-export { EventEmitter } from "https://deno.land/std@0.91.0/node/events.ts";
+} from "https://deno.land/std@0.97.0/fmt/colors.ts";
+export { EventEmitter } from "https://deno.land/std@0.97.0/node/events.ts";
 
 /**
  * Rollup
  */
 
-// @deno-types="https://unpkg.com/rollup@2.42.3/dist/rollup.d.ts"
+// @deno-types="https://unpkg.com/rollup@2.50.4/dist/rollup.d.ts"
 export {
   rollup,
   VERSION,
-} from "https://unpkg.com/rollup@2.42.3/dist/es/rollup.browser.js";
+} from "https://unpkg.com/rollup@2.50.4/dist/es/rollup.browser.js";
 export type {
   AddonHook,
   AddonHookFunction,
@@ -131,7 +131,7 @@ export type {
   WarningHandler,
   WarningHandlerWithDefault,
   WatchChangeHook,
-} from "https://unpkg.com/rollup@2.42.3/dist/rollup.d.ts";
+} from "https://unpkg.com/rollup@2.50.4/dist/rollup.d.ts";
 
 /**
  * deno.land/x

--- a/deps.ts
+++ b/deps.ts
@@ -29,11 +29,11 @@ export { EventEmitter } from "https://deno.land/std@0.97.0/node/events.ts";
  * Rollup
  */
 
-// @deno-types="https://unpkg.com/rollup@2.50.4/dist/rollup.d.ts"
+// @deno-types="https://unpkg.com/rollup@2.50.5/dist/rollup.d.ts"
 export {
   rollup,
   VERSION,
-} from "https://unpkg.com/rollup@2.50.4/dist/es/rollup.browser.js";
+} from "https://unpkg.com/rollup@2.50.5/dist/es/rollup.browser.js";
 export type {
   AddonHook,
   AddonHookFunction,
@@ -60,6 +60,7 @@ export type {
   GlobalsOption,
   HasModuleSideEffects,
   InputOption,
+  InputOptions,
   InternalModuleFormat,
   InteropType,
   IsExternal,
@@ -131,21 +132,21 @@ export type {
   WarningHandler,
   WarningHandlerWithDefault,
   WatchChangeHook,
-} from "https://unpkg.com/rollup@2.50.4/dist/rollup.d.ts";
+} from "https://unpkg.com/rollup@2.50.5/dist/rollup.d.ts";
 
 /**
  * deno.land/x
  */
 
-export { Command } from "https://deno.land/x/cliffy@v0.18.1/command/mod.ts";
+export { Command } from "https://deno.land/x/cliffy@v0.19.1/command/mod.ts";
 export type {
   IParseResult,
   ITypeInfo,
-} from "https://deno.land/x/cliffy@v0.18.1/command/mod.ts";
+} from "https://deno.land/x/cliffy@v0.19.1/command/mod.ts";
 
 /**
  * esm.sh
  */
 
 export { default as ms } from "https://esm.sh/ms@2.1.3";
-export { default as pm } from "https://esm.sh/picomatch@2.2.2";
+export { default as pm } from "https://esm.sh/picomatch@2.3.0";

--- a/egg.json
+++ b/egg.json
@@ -1,7 +1,7 @@
 {
   "name": "drollup",
   "description": "Next-generation ES module bundler for Deno ported from Rollup.",
-  "version": "2.42.3+0.17.1",
+  "version": "2.50.5+0.18.0",
   "repository": "https://github.com/cmorten/deno-rollup",
   "stable": true,
   "files": [
@@ -17,6 +17,9 @@
     "./ROLLUP_LICENSE.md",
     "./.github/CHANGELOG.md"
   ],
+  "checkFormat": false,
+  "checkTests": false,
+  "checkInstallation": false,
   "check": false,
   "entry": "./mod.ts",
   "homepage": "https://github.com/cmorten/deno-rollup",

--- a/examples/css/README.md
+++ b/examples/css/README.md
@@ -13,7 +13,7 @@ run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/css/rollup.build.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/css/rollup.build.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.build.ts
@@ -39,7 +39,7 @@ Alternatively you can use the Rollup CLI to bundle files.
 Install the CLI:
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.
@@ -59,7 +59,7 @@ on disk run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/css/rollup.watch.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/css/rollup.watch.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.watch.ts
@@ -78,7 +78,7 @@ Alternatively you can use the Rollup CLI to watch and rebuild your bundle.
 Install the CLI (same as before):
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.

--- a/examples/helloDeno/README.md
+++ b/examples/helloDeno/README.md
@@ -21,7 +21,7 @@ run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/helloDeno/rollup.build.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/helloDeno/rollup.build.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.build.ts
@@ -43,7 +43,7 @@ Alternatively you can use the Rollup CLI to bundle files.
 Install the CLI:
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.
@@ -63,7 +63,7 @@ on disk run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/helloDeno/rollup.watch.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/helloDeno/rollup.watch.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.watch.ts
@@ -82,7 +82,7 @@ Alternatively you can use the Rollup CLI to watch and rebuild your bundle.
 Install the CLI (same as before):
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.

--- a/examples/html/README.md
+++ b/examples/html/README.md
@@ -13,7 +13,7 @@ run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/html/rollup.build.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/html/rollup.build.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.build.ts
@@ -39,7 +39,7 @@ Alternatively you can use the Rollup CLI to bundle files.
 Install the CLI:
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.
@@ -59,7 +59,7 @@ on disk run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/html/rollup.watch.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/html/rollup.watch.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.watch.ts
@@ -78,7 +78,7 @@ Alternatively you can use the Rollup CLI to watch and rebuild your bundle.
 Install the CLI (same as before):
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.

--- a/examples/image/README.md
+++ b/examples/image/README.md
@@ -13,7 +13,7 @@ run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/image/rollup.build.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/image/rollup.build.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.build.ts
@@ -39,7 +39,7 @@ Alternatively you can use the Rollup CLI to bundle files.
 Install the CLI:
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.
@@ -59,7 +59,7 @@ on disk run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/image/rollup.watch.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/image/rollup.watch.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.watch.ts
@@ -78,7 +78,7 @@ Alternatively you can use the Rollup CLI to watch and rebuild your bundle.
 Install the CLI (same as before):
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.

--- a/examples/importmap/README.md
+++ b/examples/importmap/README.md
@@ -20,7 +20,7 @@ run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/importmap/rollup.build.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/importmap/rollup.build.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.build.ts
@@ -45,7 +45,7 @@ Alternatively you can use the Rollup CLI to bundle files.
 Install the CLI:
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.
@@ -65,7 +65,7 @@ on disk run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/importmap/rollup.watch.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/importmap/rollup.watch.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.watch.ts
@@ -84,7 +84,7 @@ Alternatively you can use the Rollup CLI to watch and rebuild your bundle.
 Install the CLI (same as before):
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.

--- a/examples/json/README.md
+++ b/examples/json/README.md
@@ -13,7 +13,7 @@ run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/json/rollup.build.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/json/rollup.build.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.build.ts
@@ -35,7 +35,7 @@ Alternatively you can use the Rollup CLI to bundle files.
 Install the CLI:
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.
@@ -55,7 +55,7 @@ on disk run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/json/rollup.watch.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/json/rollup.watch.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.watch.ts
@@ -74,7 +74,7 @@ Alternatively you can use the Rollup CLI to watch and rebuild your bundle.
 Install the CLI (same as before):
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.

--- a/examples/livereload/README.md
+++ b/examples/livereload/README.md
@@ -13,7 +13,7 @@ You can use the Rollup CLI to bundle files.
 Install the CLI:
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --allow-run --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --allow-run --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.
@@ -33,7 +33,7 @@ Alternatively you can use the Rollup CLI to watch and rebuild your bundle.
 Install the CLI (same as before):
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --allow-run --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --allow-run --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.

--- a/examples/postcss/README.md
+++ b/examples/postcss/README.md
@@ -17,7 +17,7 @@ run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/postcss/rollup.build.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/postcss/rollup.build.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.build.ts
@@ -43,7 +43,7 @@ Alternatively you can use the Rollup CLI to bundle files.
 Install the CLI:
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.
@@ -63,7 +63,7 @@ on disk run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/postcss/rollup.watch.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/postcss/rollup.watch.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.watch.ts
@@ -82,7 +82,7 @@ Alternatively you can use the Rollup CLI to watch and rebuild your bundle.
 Install the CLI (same as before):
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.

--- a/examples/serve/README.md
+++ b/examples/serve/README.md
@@ -13,7 +13,7 @@ You can use the Rollup CLI to bundle files.
 Install the CLI:
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --allow-run --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --allow-run --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.
@@ -33,7 +33,7 @@ Alternatively you can use the Rollup CLI to watch and rebuild your bundle.
 Install the CLI (same as before):
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --allow-run --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --allow-run --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.

--- a/examples/terser/README.md
+++ b/examples/terser/README.md
@@ -21,7 +21,7 @@ run:
 
 ```console
 # Direct from repository
-deno run --allow-read --allow-write="./dist" --allow-net --allow-env --unstable --no-check https://deno.land/x/drollup@2.42.3+0.17.1/examples/terser/rollup.build.ts
+deno run --allow-read --allow-write="./dist" --allow-net --allow-env --unstable --no-check https://deno.land/x/drollup@2.50.5+0.18.0/examples/terser/rollup.build.ts
 
 # When cloned locally
 deno run --allow-read --allow-write="./dist" --allow-net --allow-env --unstable --no-check ./rollup.build.ts
@@ -43,7 +43,7 @@ Alternatively you can use the Rollup CLI to bundle files.
 Install the CLI:
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.
@@ -63,7 +63,7 @@ on disk run:
 
 ```console
 # Direct from repository
-deno run --allow-read --allow-write="./dist" --allow-net --allow-env --unstable --no-check https://deno.land/x/drollup@2.42.3+0.17.1/examples/terser/rollup.watch.ts
+deno run --allow-read --allow-write="./dist" --allow-net --allow-env --unstable --no-check https://deno.land/x/drollup@2.50.5+0.18.0/examples/terser/rollup.watch.ts
 
 # When cloned locally
 deno run --allow-read --allow-write="./dist" --allow-net --allow-env --unstable --no-check ./rollup.watch.ts
@@ -82,7 +82,7 @@ Alternatively you can use the Rollup CLI to watch and rebuild your bundle.
 Install the CLI (same as before):
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.

--- a/examples/virtual/README.md
+++ b/examples/virtual/README.md
@@ -13,7 +13,7 @@ run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/virtual/rollup.build.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/virtual/rollup.build.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.build.ts
@@ -35,7 +35,7 @@ Alternatively you can use the Rollup CLI to bundle files.
 Install the CLI:
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.
@@ -55,7 +55,7 @@ on disk run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/virtual/rollup.watch.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/virtual/rollup.watch.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.watch.ts
@@ -74,7 +74,7 @@ Alternatively you can use the Rollup CLI to watch and rebuild your bundle.
 Install the CLI (same as before):
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.

--- a/examples/yaml/README.md
+++ b/examples/yaml/README.md
@@ -13,7 +13,7 @@ run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/yaml/rollup.build.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/yaml/rollup.build.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.build.ts
@@ -35,7 +35,7 @@ Alternatively you can use the Rollup CLI to bundle files.
 Install the CLI:
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.
@@ -55,7 +55,7 @@ on disk run:
 
 ```console
 # Direct from repository
-deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/examples/yaml/rollup.watch.ts
+deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/examples/yaml/rollup.watch.ts
 
 # When cloned locally
 deno run --allow-read="./" --allow-write="./dist" --allow-net="deno.land" --allow-env --unstable ./rollup.watch.ts
@@ -74,7 +74,7 @@ Alternatively you can use the Rollup CLI to watch and rebuild your bundle.
 Install the CLI (same as before):
 
 ```console
-deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.42.3+0.17.1/rollup.ts
+deno install -f -q --allow-read --allow-write --allow-net --allow-env --unstable https://deno.land/x/drollup@2.50.5+0.18.0/rollup.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.

--- a/plugins/css/README.md
+++ b/plugins/css/README.md
@@ -15,7 +15,7 @@ Create a `rollup.config.js`
 import the plugin:
 
 ```ts
-import { css } from "https://deno.land/x/drollup@2.42.3+0.17.1/plugins/css/mod.ts";
+import { css } from "https://deno.land/x/drollup@2.50.5+0.18.0/plugins/css/mod.ts";
 
 export default {
   input: "./src/mod.ts",

--- a/plugins/importmap/README.md
+++ b/plugins/importmap/README.md
@@ -20,7 +20,7 @@ Create a `rollup.config.js`
 import the plugin:
 
 ```ts
-import { rollupImportMapPlugin } from "https://deno.land/x/drollup@2.42.3+0.17.1/plugins/importmap/mod.ts";
+import { rollupImportMapPlugin } from "https://deno.land/x/drollup@2.50.5+0.18.0/plugins/importmap/mod.ts";
 
 export default {
   input: "./src/mod.ts",

--- a/plugins/importmap/mod.ts
+++ b/plugins/importmap/mod.ts
@@ -1,22 +1,22 @@
 /**
  * Derived from <https://github.com/trygve-lie/rollup-plugin-import-map>
- * 
+ *
  * Licensed as follows:
- * 
+ *
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Trygve Lie
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -69,7 +69,7 @@ export interface RollupImportMapOptions {
   /**
    * Set the base url from which the relative-URL-like addresses
    * are resolved.
-   * 
+   *
    * If not provided, the base url will the location of the import
    * map if an import map path is provided, or the current working
    * directory if not.
@@ -79,8 +79,8 @@ export interface RollupImportMapOptions {
 
 /**
  * isBareImportSpecifier
- * 
- * @param {string} address 
+ *
+ * @param {string} address
  * @returns {boolean}
  * @private
  */
@@ -99,9 +99,9 @@ const isBareImportSpecifier = (address: string) => {
 
 /**
  * validate
- * 
- * @param {ImportMapObject} importMap 
- * @param {NormalizedInputOptions} options 
+ *
+ * @param {ImportMapObject} importMap
+ * @param {NormalizedInputOptions} options
  * @private
  */
 const validate = (
@@ -139,9 +139,9 @@ const validate = (
 
 /**
  * readFile
- * 
- * @param {string} pathname 
- * @param options 
+ *
+ * @param {string} pathname
+ * @param options
  * @private
  */
 const readFile = async (
@@ -160,10 +160,10 @@ const readFile = async (
 
 /**
  * rollupImportMapPlugin
- * 
+ *
  * Apply [import map](https://github.com/WICG/import-maps)
  * mappings to ES modules.
- * 
+ *
  * @param {RollupImportMapOptions} rollupImportMapOptions
  * @returns {Plugin}
  * @public

--- a/plugins/postcss/README.md
+++ b/plugins/postcss/README.md
@@ -16,7 +16,7 @@ Create a `rollup.config.js`
 import the plugin:
 
 ```ts
-import { postcss } from "https://deno.land/x/drollup@2.42.3+0.17.1/plugins/postcss/mod.ts";
+import { postcss } from "https://deno.land/x/drollup@2.50.5+0.18.0/plugins/postcss/mod.ts";
 
 export default {
   input: "./src/mod.ts",

--- a/plugins/terser/README.md
+++ b/plugins/terser/README.md
@@ -18,7 +18,7 @@ Create a `rollup.config.js`
 import the plugin:
 
 ```ts
-import { terser } from "https://deno.land/x/drollup@2.42.3+0.17.1/plugins/terser/mod.ts";
+import { terser } from "https://deno.land/x/drollup@2.50.5+0.18.0/plugins/terser/mod.ts";
 
 export default {
   input: "./src/mod.ts",

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -16,7 +16,7 @@ const decoder = new TextDecoder();
 
 /**
  * build
- * 
+ *
  * @param {MergedRollupOptions} inputOptions
  * @param {boolen} silent
  * @private

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -2,7 +2,11 @@
  * Derived from <https://github.com/rollup/rollup/blob/v2.42.3/cli/run/watch-cli.ts>
  */
 
-import type { IParseResult, MergedRollupOptions } from "../../deps.ts";
+import type {
+  IParseResult,
+  MergedRollupOptions,
+  RollupError,
+} from "../../deps.ts";
 import type { RollupWatcher } from "../rollup/mod.ts";
 import { VERSION, watch as _watch } from "../rollup/mod.ts";
 import { bold, cyan, green, ms, underline } from "../../deps.ts";
@@ -49,6 +53,16 @@ export async function watch(program: IParseResult) {
   let reloadingConfig = false;
   let aborted = false;
   let configFileData: string | null = null;
+
+  window.addEventListener("unload", () => {
+    console.log("unload");
+    if (watcher) {
+      watcher.close();
+    }
+    if (configWatcher) {
+      configWatcher.close();
+    }
+  });
 
   const configFile = program.options.config
     ? await getConfigPath(program.options.config)
@@ -184,7 +198,9 @@ export async function watch(program: IParseResult) {
       }
 
       if ("result" in event && event.result) {
-        event.result.close().catch((error) => handleError(error, true));
+        event.result.close().catch((error: RollupError) =>
+          handleError(error, true)
+        );
       }
     });
   }

--- a/src/ensureArray.ts
+++ b/src/ensureArray.ts
@@ -4,7 +4,7 @@
 
 /**
  * ensureArray
- * 
+ *
  * @param {any} items
  * @returns {any[]}
  * @private

--- a/src/error.ts
+++ b/src/error.ts
@@ -6,7 +6,7 @@ import type { RollupError } from "../deps.ts";
 
 /**
  * error
- * 
+ *
  * @param {Error|RollupError} base
  * @private
  */

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -12,7 +12,7 @@ export const logOutput = console.log.bind(console);
 
 /**
  * handleError
- * 
+ *
  * @param {RollupErr} err
  * @param {boolean} recover
  * @private

--- a/src/mergeOptions.ts
+++ b/src/mergeOptions.ts
@@ -2,7 +2,6 @@
  * Derived from <https://github.com/rollup/rollup/blob/v2.42.3/src/utils/options/mergeOptions.ts>
  */
 
-// deno-lint-ignore-file ban-types
 import type { CommandConfigObject, GenericConfigObject } from "./types.ts";
 import type {
   ExternalOption,
@@ -10,6 +9,7 @@ import type {
   OutputOptions,
   Plugin,
   RollupCache,
+  RollupWarning,
   WarningHandler,
   WarningHandlerWithDefault,
 } from "../deps.ts";
@@ -18,20 +18,20 @@ import { ensureArray } from "./ensureArray.ts";
 
 /**
  * defaultOnWarn
- * 
+ *
  * @param {any} warning
  * @private
  */
-const defaultOnWarn: WarningHandler = (warning) =>
+const defaultOnWarn: WarningHandler = (warning: RollupWarning) =>
   console.warn(warning.message || warning);
 
 /**
  * warnUnknownOptions
- * 
- * @param {GenericConfigObject} passedOptions 
- * @param {string[]} validOptions 
- * @param {string} optionType 
- * @param {WarningHandler} warn 
+ *
+ * @param {GenericConfigObject} passedOptions
+ * @param {string[]} validOptions
+ * @param {string} optionType
+ * @param {WarningHandler} warn
  * @param {RegExp} ignoredKeys
  * @private
  */
@@ -80,7 +80,7 @@ export const commandAliases: { [key: string]: string } = {
 
 /**
  * mergeOptions
- * 
+ *
  * @param {GenericConfigObject} config
  * @param {GenericConfigObject} rawCommandOptions
  * @returns {MergedRollupOptions}
@@ -144,7 +144,7 @@ export function mergeOptions(
 
 /**
  * getCommandOptions
- * 
+ *
  * @param {GenericConfigObject} rawCommandOptions
  * @returns {CommandConfigObject}
  * @private
@@ -181,7 +181,7 @@ type CompleteInputOptions<U extends keyof InputOptions> = {
 
 /**
  * mergeInputOptions
- * 
+ *
  * @param {GenericConfigObject} config
  * @param {CommandConfigObject} overrides
  * @returns {InputOptions}
@@ -198,8 +198,8 @@ function mergeInputOptions(
   const inputOptions: CompleteInputOptions<keyof InputOptions> = {
     acorn: getOption("acorn"),
     acornInjectPlugins: config.acornInjectPlugins as
-      | Function
-      | Function[]
+      | (() => unknown)[]
+      | (() => unknown)
       | undefined,
     cache: config.cache as false | RollupCache | undefined,
     context: getOption("context"),
@@ -207,6 +207,7 @@ function mergeInputOptions(
     external: getExternal(config, overrides),
     inlineDynamicImports: getOption("inlineDynamicImports"),
     input: getOption("input") || [],
+    makeAbsoluteExternalsRelative: getOption("makeAbsoluteExternalsRelative"),
     manualChunks: getOption("manualChunks"),
     moduleContext: getOption("moduleContext"),
     onwarn: getOnWarn(config, defaultOnWarnHandler),
@@ -235,7 +236,7 @@ function mergeInputOptions(
 
 /**
  * getExternal
- * 
+ *
  * @param {GenericConfigObject} config
  * @param {CommandConfigObject} overrides
  * @returns {ExternalOption}
@@ -256,7 +257,7 @@ const getExternal = (
 
 /**
  * getOnWarn
- * 
+ *
  * @param {GenericConfigObject} config
  * @param {WarningHandler} defaultOnWarnHandler
  * @returns {WarningHandler}
@@ -267,7 +268,7 @@ const getOnWarn = (
   defaultOnWarnHandler: WarningHandler,
 ): WarningHandler =>
   config.onwarn
-    ? (warning) =>
+    ? (warning: RollupWarning) =>
       (config.onwarn as WarningHandlerWithDefault)(
         warning,
         defaultOnWarnHandler,
@@ -276,7 +277,7 @@ const getOnWarn = (
 
 /**
  * getObjectOption
- * 
+ *
  * @param {GenericConfigObject} config
  * @param {CommandConfigObject} overrides
  * @param {string} name
@@ -300,7 +301,7 @@ const getObjectOption = (
 
 /**
  * getWatch
- * 
+ *
  * @param {GenericConfigObject} config
  * @param {GenericConfigObject} overrides
  * @param {string} name
@@ -315,7 +316,7 @@ const getWatch = (
 
 /**
  * normalizeObjectOptionValue
- * 
+ *
  * @param {any} optionValue
  * @returns {any}
  * @private
@@ -345,7 +346,7 @@ type CompleteOutputOptions<U extends keyof OutputOptions> = {
 
 /**
  * mergeOutputOptions
- * 
+ *
  * @param {GenericConfigObject} config
  * @param {GenericConfigObject} overrides
  * @returns {OutputOptions}

--- a/src/mergeOptions.ts
+++ b/src/mergeOptions.ts
@@ -393,6 +393,7 @@ function mergeOutputOptions(
     preferConst: getOption("preferConst"),
     preserveModules: getOption("preserveModules"),
     preserveModulesRoot: getOption("preserveModulesRoot"),
+    sanitizeFileName: getOption("sanitizeFileName"),
     sourcemap: getOption("sourcemap"),
     sourcemapExcludeSources: getOption("sourcemapExcludeSources"),
     sourcemapFile: getOption("sourcemapFile"),

--- a/src/notImplemented.ts
+++ b/src/notImplemented.ts
@@ -2,7 +2,7 @@ import { handleError } from "./logging.ts";
 
 /**
  * notImplemented
- * 
+ *
  * @param {string} [msg]
  * @throws {Error}
  * @private

--- a/src/relativeId.ts
+++ b/src/relativeId.ts
@@ -6,7 +6,7 @@ import { isAbsolute, relative } from "../deps.ts";
 
 /**
  * relativeId
- * 
+ *
  * @param {string} id
  * @returns {string}
  * @private

--- a/src/rollup-plugin-deno-resolver/denoResolver.test.ts
+++ b/src/rollup-plugin-deno-resolver/denoResolver.test.ts
@@ -173,7 +173,7 @@ describe("denoResolver", () => {
         description: "relative javascript id",
         id: relativeJs,
         expectedCode:
-          `// deno-lint-ignore-file no-unused-vars\nconst a = [];${newline}console.log("Hello Deno!");${newline}`,
+          `// deno-lint-ignore-file no-unused-vars${newline}const a = [];${newline}console.log("Hello Deno!");${newline}`,
       },
       {
         description: "relative typescript id",

--- a/src/rollup-plugin-deno-resolver/denoResolver.test.ts
+++ b/src/rollup-plugin-deno-resolver/denoResolver.test.ts
@@ -173,22 +173,25 @@ describe("denoResolver", () => {
         description: "relative javascript id",
         id: relativeJs,
         expectedCode:
-          `const a = [];${newline}console.log("Hello Deno!");${newline}`,
+          `// deno-lint-ignore-file no-unused-vars\nconst a = [];${newline}console.log("Hello Deno!");${newline}`,
       },
       {
         description: "relative typescript id",
         id: relative,
-        expectedCode: `const a = [];\nconsole.log("Hello Deno!");\n`,
+        expectedCode:
+          `// deno-lint-ignore-file no-unused-vars\nconst a = [];\nconsole.log("Hello Deno!");\n`,
       },
       {
         description: "absolute typescript id",
         id: absolute,
-        expectedCode: `const a = [];\nconsole.log("Hello Deno!");\n`,
+        expectedCode:
+          `// deno-lint-ignore-file no-unused-vars\nconst a = [];\nconsole.log("Hello Deno!");\n`,
       },
       {
         description: "file URL typescript id",
         id: fileUrl,
-        expectedCode: `const a = [];\nconsole.log("Hello Deno!");\n`,
+        expectedCode:
+          `// deno-lint-ignore-file no-unused-vars\nconst a = [];\nconsole.log("Hello Deno!");\n`,
       },
       {
         description: "http URL id",

--- a/src/rollup-plugin-deno-resolver/denoResolver.ts
+++ b/src/rollup-plugin-deno-resolver/denoResolver.ts
@@ -16,19 +16,19 @@ export type DenoResolverOptions = {
 
 /**
  * denoResolver
- * 
+ *
  * Resolver plugin for Deno. Handles relative, absolute
  * and URL imports. Typescript files are detected automatically
  * by extension matching, and transpiled using the
  * `Deno.emit()` API.
- * 
+ *
  * Accepts fetch options to pass to `fetch()` when requesting
  * remote URL imports, compiler options to pass to
  * `Deno.emit()` when transpiling typescript imports.
- * 
- * @param {DenoResolverOptions} [opts] 
- * @param {RequestInit} [opts.fetchOpts] 
- * @param {Deno.CompilerOptions} [opts.compilerOpts] 
+ *
+ * @param {DenoResolverOptions} [opts]
+ * @param {RequestInit} [opts.fetchOpts]
+ * @param {Deno.CompilerOptions} [opts.compilerOpts]
  * @returns {Plugin}
  * @public
  */

--- a/src/rollup-plugin-deno-resolver/ensureUrl.ts
+++ b/src/rollup-plugin-deno-resolver/ensureUrl.ts
@@ -4,8 +4,8 @@ const RE_PATH_MALFORMED_FILE_URL = /^((file):)(?:\\+|\/)([A-Za-z]:)?/;
 
 /**
  * ensureUrl
- * 
- * @param {string} source 
+ *
+ * @param {string} source
  * @returns {string|null}
  * @private
  */

--- a/src/rollup-plugin-deno-resolver/exists.test.ts
+++ b/src/rollup-plugin-deno-resolver/exists.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "../../test/deps.ts";
-import { bold, red, resolve, toFileUrl } from "../../deps.ts";
+import { bold, red, toFileUrl } from "../../deps.ts";
 import { describe, it } from "../../test/mod.ts";
 import { exists } from "./exists.ts";
 

--- a/src/rollup-plugin-deno-resolver/exists.ts
+++ b/src/rollup-plugin-deno-resolver/exists.ts
@@ -6,9 +6,9 @@ import { notImplemented } from "../notImplemented.ts";
 
 /**
  * exists
- * 
- * @param {URL} url 
- * @param {RequestInit} [fetchOpts] 
+ *
+ * @param {URL} url
+ * @param {RequestInit} [fetchOpts]
  * @returns {Promise<boolean>}
  * @private
  */

--- a/src/rollup-plugin-deno-resolver/getUrlBase.ts
+++ b/src/rollup-plugin-deno-resolver/getUrlBase.ts
@@ -2,7 +2,7 @@ import { join, sep, toFileUrl } from "../../deps.ts";
 
 /**
  * getUrlBase
- * 
+ *
  * @returns {URL}
  * @private
  */

--- a/src/rollup-plugin-deno-resolver/handleUnresolvedId.ts
+++ b/src/rollup-plugin-deno-resolver/handleUnresolvedId.ts
@@ -3,9 +3,9 @@ import { error } from "../error.ts";
 
 /**
  * handleUnresolvedId
- * 
- * @param {string} id 
- * @param {string} [importer] 
+ *
+ * @param {string} id
+ * @param {string} [importer]
  * @returns {null}
  * @private
  */

--- a/src/rollup-plugin-deno-resolver/isTypescript.ts
+++ b/src/rollup-plugin-deno-resolver/isTypescript.ts
@@ -2,8 +2,8 @@ const RE_TS = /\.tsx?$/;
 
 /**
  * isTypescript
- * 
- * @param {string} source 
+ *
+ * @param {string} source
  * @returns {boolean}
  * @private
  */

--- a/src/rollup-plugin-deno-resolver/loadUrl.ts
+++ b/src/rollup-plugin-deno-resolver/loadUrl.ts
@@ -4,9 +4,9 @@ const decoder = new TextDecoder("utf-8");
 
 /**
  * loadUrl
- * 
- * @param {URL} url 
- * @param {RequestInit} [fetchOpts] 
+ *
+ * @param {URL} url
+ * @param {RequestInit} [fetchOpts]
  * @returns {Promise<string>}
  * @private
  */

--- a/src/rollup-plugin-deno-resolver/parse.ts
+++ b/src/rollup-plugin-deno-resolver/parse.ts
@@ -3,7 +3,7 @@ import { getUrlBase } from "./getUrlBase.ts";
 
 /**
  * parse
- * 
+ *
  * @param {string} id
  * @returns {URL|null}
  * @private

--- a/src/rollup-plugin-deno-resolver/resolveId.ts
+++ b/src/rollup-plugin-deno-resolver/resolveId.ts
@@ -12,8 +12,8 @@ const RE_WIN_DEVICE = /^([A-Za-z]:)(\\+|\/)/;
 
 /**
  * resolveId
- * 
- * @param {string} source 
+ *
+ * @param {string} source
  * @param {string} [importer]
  * @returns {string}
  * @private

--- a/src/rollup/createFilter.ts
+++ b/src/rollup/createFilter.ts
@@ -1,22 +1,22 @@
 /**
  * Dervived from <https://github.com/rollup/plugins/tree/pluginutils-v4.1.0/packages/pluginutils>
- * 
+ *
  * Licensed as follows:
- * 
+ *
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2019 RollupJS Plugin Contributors (https://github.com/rollup/plugins/graphs/contributors)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,9 +31,9 @@ import { ensureArray } from "../ensureArray.ts";
 
 /**
  * getMatcherString
- * 
- * @param {string} id 
- * @param {string|false|null|undefined} resolutionBase 
+ *
+ * @param {string} id
+ * @param {string|false|null|undefined} resolutionBase
  * @returns {string}
  * @private
  */
@@ -64,9 +64,9 @@ export type CreateFilter = (id: string | unknown) => boolean;
 
 /**
  * createFilter
- * 
- * @param {FilterPattern} include 
- * @param {FilterPattern} exclude 
+ *
+ * @param {FilterPattern} include
+ * @param {FilterPattern} exclude
  * @param {any} options
  * @returns {CreateFilter}
  * @private

--- a/src/rollup/fileWatcher.ts
+++ b/src/rollup/fileWatcher.ts
@@ -2,7 +2,7 @@ import { Task } from "./task.ts";
 
 /**
  * FileWatcher
- * 
+ *
  * @private
  */
 export class FileWatcher {

--- a/src/rollup/generate.ts
+++ b/src/rollup/generate.ts
@@ -3,9 +3,9 @@ import { supportUrlSources } from "./supportUrlSources.ts";
 
 /**
  * generate
- * 
- * @param {RollupBuild} this 
- * @param {OutputOptions} options 
+ *
+ * @param {RollupBuild} this
+ * @param {OutputOptions} options
  * @returns {Promise<RollupOutput>}
  * @private
  */

--- a/src/rollup/getDestination.ts
+++ b/src/rollup/getDestination.ts
@@ -3,7 +3,7 @@ import { dirname, resolve } from "../../deps.ts";
 
 /**
  * getDestination
- * 
+ *
  * @param {OutputOptions} options
  * @returns {string|null}
  * @private

--- a/src/rollup/mod.ts
+++ b/src/rollup/mod.ts
@@ -24,7 +24,7 @@ export { rollup, VERSION, watch };
 /**
  * Prevent `warning: Compiled module not found` by re-exporting
  * types explicitly.
- * 
+ *
  * @public
  */
 export type {
@@ -163,8 +163,8 @@ export interface RollupWatcher extends
  * @public
  */
 export interface InputOptions {
-  acorn?: Object;
-  acornInjectPlugins?: Function | Function[];
+  acorn?: Record<string, unknown> | undefined;
+  acornInjectPlugins?: (() => unknown)[] | (() => unknown) | undefined;
   cache?: false | RollupCache;
   context?: string;
   experimentalCacheExpiry?: number;
@@ -189,6 +189,7 @@ export interface InputOptions {
   treeshake?: boolean | TreeshakingOptions;
   watch?: WatcherOptions | false;
   denoResolver?: DenoResolverOptions;
+  sanitizeFileName?: boolean;
 }
 
 /**

--- a/src/rollup/mod.ts
+++ b/src/rollup/mod.ts
@@ -1,15 +1,7 @@
-// deno-lint-ignore-file ban-types
 import type {
-  ExternalOption,
-  InputOption,
-  ManualChunksOption,
+  InputOptions as _InputOptions,
   OutputOptions,
-  Plugin,
-  PreserveEntrySignaturesOption,
-  RollupCache,
   RollupWatcherEvent,
-  TreeshakingOptions,
-  WarningHandlerWithDefault,
 } from "../../deps.ts";
 import { VERSION } from "../../deps.ts";
 import { DenoResolverOptions } from "../rollup-plugin-deno-resolver/denoResolver.ts";
@@ -162,34 +154,8 @@ export interface RollupWatcher extends
 /**
  * @public
  */
-export interface InputOptions {
-  acorn?: Record<string, unknown> | undefined;
-  acornInjectPlugins?: (() => unknown)[] | (() => unknown) | undefined;
-  cache?: false | RollupCache;
-  context?: string;
-  experimentalCacheExpiry?: number;
-  external?: ExternalOption;
-  /** @deprecated Use the "inlineDynamicImports" output option instead. */
-  inlineDynamicImports?: boolean;
-  input?: InputOption;
-  /** @deprecated Use the "manualChunks" output option instead. */
-  manualChunks?: ManualChunksOption;
-  moduleContext?: ((id: string) => string | null | undefined) | {
-    [id: string]: string;
-  };
-  onwarn?: WarningHandlerWithDefault;
-  perf?: boolean;
-  plugins?: Plugin[];
-  preserveEntrySignatures?: PreserveEntrySignaturesOption;
-  /** @deprecated Use the "preserveModules" output option instead. */
-  preserveModules?: boolean;
-  preserveSymlinks?: boolean;
-  shimMissingExports?: boolean;
-  strictDeprecations?: boolean;
-  treeshake?: boolean | TreeshakingOptions;
-  watch?: WatcherOptions | false;
+export interface InputOptions extends _InputOptions {
   denoResolver?: DenoResolverOptions;
-  sanitizeFileName?: boolean;
 }
 
 /**

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -45,7 +45,7 @@ export async function rollup(
 
   try {
     // deno-lint-ignore no-explicit-any
-    const bundle = await _rollup(options as any);
+    const bundle = await _rollup(options);
 
     return new Proxy(bundle, {
       get: (target, prop, receiver) => {

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -44,7 +44,8 @@ export async function rollup(
   };
 
   try {
-    const bundle = await _rollup(options);
+    // deno-lint-ignore no-explicit-any
+    const bundle = await _rollup(options as any);
 
     return new Proxy(bundle, {
       get: (target, prop, receiver) => {

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -8,23 +8,23 @@ import { error } from "../error.ts";
 
 /**
  * rollup
- * 
+ *
  * The `rollup` function receives an input options object as parameter
  * and returns a Promise that resolves to a `bundle` object with various
  * properties and methods as shown below. During this step, Rollup will
  * build the module graph and perform tree-shaking, but will not
  * generate any output.
- * 
+ *
  * On a `bundle` object, you can call `bundle.generate` multiple times with
  * different output options objects to generate different bundles
  * in-memory. If you directly want to write them to disk, use `bundle.write`
  * instead.
- * 
+ *
  * Once you're finished with the `bundle` object, you should call
  * `bundle.close()`, which will let plugins clean up their external
  * processes or services via the `closeBundle` hook.
- * 
- * @param {RollupOptions} options 
+ *
+ * @param {RollupOptions} options
  * @returns {Promise<RollupBuild>}
  * @public
  */
@@ -44,7 +44,6 @@ export async function rollup(
   };
 
   try {
-    // deno-lint-ignore no-explicit-any
     const bundle = await _rollup(options);
 
     return new Proxy(bundle, {

--- a/src/rollup/supportUrlSources.ts
+++ b/src/rollup/supportUrlSources.ts
@@ -6,8 +6,8 @@ const RE_PATH_MALFORMED_FILE_URL = /(.*)(file:\/)([^\/]?)/;
 
 /**
  * supportUrlSources
- * 
- * @param {OutputOptions} options 
+ *
+ * @param {OutputOptions} options
  * @returns {OutputOptions}
  * @private
  */

--- a/src/rollup/task.ts
+++ b/src/rollup/task.ts
@@ -16,7 +16,7 @@ import { Watcher } from "./watcher.ts";
 
 /**
  * Task
- * 
+ *
  * @private
  */
 export class Task {

--- a/src/rollup/watch.ts
+++ b/src/rollup/watch.ts
@@ -6,7 +6,7 @@ import { handleError } from "../logging.ts";
 
 /**
  * WatchEmitter
- * 
+ *
  * @private
  */
 class WatchEmitter extends EventEmitter {
@@ -20,7 +20,7 @@ class WatchEmitter extends EventEmitter {
 
 /**
  * watch
- * 
+ *
  * The `watch` function rebuilds your bundle when it detects that the
  * individual modules have changed on disk. It is used internally when
  * you run Rollup from the command line with the `--watch` flag. Note
@@ -28,8 +28,8 @@ class WatchEmitter extends EventEmitter {
  * responsibility to call `event.result.close()` in response to the
  * `BUNDLE_END` event to allow plugins to clean up resources in the
  * `closeBundle` hook.
- * 
- * @param {RollupWatchOptions|RollupWatchOptions[]} config 
+ *
+ * @param {RollupWatchOptions|RollupWatchOptions[]} config
  * @returns {RollupWatcher}
  * @public
  */

--- a/src/rollup/watcher.ts
+++ b/src/rollup/watcher.ts
@@ -26,7 +26,7 @@ const eventsRewrites: Record<string, Record<string, string | "warn" | null>> = {
 
 /**
  * Watcher
- * 
+ *
  * @private
  */
 export class Watcher {

--- a/src/rollup/write.ts
+++ b/src/rollup/write.ts
@@ -8,9 +8,9 @@ export const SOURCEMAPPING_URL = "sourceMappingURL";
 
 /**
  * write
- * 
- * @param {RollupBuild} this 
- * @param {OutputOptions} options 
+ *
+ * @param {RollupBuild} this
+ * @param {OutputOptions} options
  * @returns {Promise<RollupOutput>}
  * @private
  */

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -1,5 +1,5 @@
-export * as posixPath from "https://deno.land/std@0.91.0/path/posix.ts";
-export { createRequire } from "https://deno.land/std@0.91.0/node/module.ts";
+export * as posixPath from "https://deno.land/std@0.97.0/path/posix.ts";
+export { createRequire } from "https://deno.land/std@0.97.0/node/module.ts";
 export { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 export { default as assert } from "https://esm.sh/assert@2.0.0";
 export { default as listGitHub } from "https://esm.sh/list-github-dir-content@3.0.0";

--- a/test/fixtures/hello.js
+++ b/test/fixtures/hello.js
@@ -1,2 +1,3 @@
+// deno-lint-ignore-file no-unused-vars
 const a = [];
 console.log("Hello Deno!");

--- a/test/fixtures/hello.ts
+++ b/test/fixtures/hello.ts
@@ -1,2 +1,3 @@
+// deno-lint-ignore-file no-unused-vars
 const a: string[] = [];
 console.log("Hello Deno!");

--- a/test/mod.ts
+++ b/test/mod.ts
@@ -5,9 +5,9 @@ export const TEST_TIMEOUT = 3000;
 
 /**
  * A no-op _describe_ method.
- * 
- * @param name 
- * @param fn 
+ *
+ * @param name
+ * @param fn
  */
 export function describe(_name: string, fn: () => void | Promise<void>) {
   return fn();
@@ -17,9 +17,9 @@ export type Done = (err?: Error) => void;
 
 /**
  * An _it_ wrapper around `Deno.test`.
- * 
- * @param name 
- * @param fn 
+ *
+ * @param name
+ * @param fn
  */
 export function it(
   name: string,

--- a/test/requireSham.ts
+++ b/test/requireSham.ts
@@ -38,7 +38,7 @@ const _require = createRequire(import.meta.url);
  * polyfill, designed around providing capabilities
  * for rollup's tests, and not as a production ready
  * require polyfill.
- * 
+ *
  * @param {string} path the import path
  */
 export function requireSham(path: string): any {

--- a/version.ts
+++ b/version.ts
@@ -1,5 +1,5 @@
 import { VERSION } from "./mod.ts";
 
 export const coreRollupVersion = VERSION;
-export const denoRollupVersion = "0.17.1";
+export const denoRollupVersion = "0.18.0";
 export const version = `${coreRollupVersion}+${denoRollupVersion}`;


### PR DESCRIPTION
# Issue

No issue.

## Details

Derived from and supersedes https://github.com/cmorten/deno-rollup/pull/33 - I don't have permissions to push to the contributor fork and there was a reasonable amount of work needed to fix types, appease new linting rules in Deno, appease new formatting rules in Deno and ensure that the docs were all consistent with the new version.

- chore: support Deno 1.10.2 and std 0.97.0
- feat: upgrade Rollup to 2.50.5

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required).
