### PR TITLE
[#39] Upgraded to std@0.100.0 to work with deno 1.11.4.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        deno-version: [1.10.2]
+        deno-version: [1.11.4]
 
     runs-on: ${{ matrix.os }}
 
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        deno-version: [1.10.2]
+        deno-version: [1.11.4]
 
     runs-on: ${{ matrix.os }}
 

--- a/deps.ts
+++ b/deps.ts
@@ -14,7 +14,7 @@ export {
   resolve,
   sep,
   toFileUrl,
-} from "https://deno.land/std@0.97.0/path/mod.ts";
+} from "https://deno.land/std@0.100.0/path/mod.ts";
 export {
   bold,
   cyan,
@@ -22,8 +22,8 @@ export {
   green,
   red,
   underline,
-} from "https://deno.land/std@0.97.0/fmt/colors.ts";
-export { EventEmitter } from "https://deno.land/std@0.97.0/node/events.ts";
+} from "https://deno.land/std@0.100.0/fmt/colors.ts";
+export { EventEmitter } from "https://deno.land/std@0.100.0/node/events.ts";
 
 /**
  * Rollup

--- a/examples/css/README.md
+++ b/examples/css/README.md
@@ -25,7 +25,7 @@ Rollup and then writes out the bundles.
 To view your new HTML page and bundle code run:
 
 ```console
-deno run --allow-net --allow-read https://deno.land/std@0.91.0/http/file_server.ts ./dist --port 3000
+deno run --allow-net --allow-read https://deno.land/std@0.100.0/http/file_server.ts ./dist --port 3000
 ```
 
 This uses the Deno standard library's `file_server` module to serve the static

--- a/examples/helloDeno/src/mod.ts
+++ b/examples/helloDeno/src/mod.ts
@@ -1,5 +1,5 @@
 import { myString } from "./std.ts";
-import { basename } from "https://deno.land/std@0.83.0/path/mod.ts";
+import { basename } from "https://deno.land/std@0.100.0/path/mod.ts";
 
 export async function main(): Promise<void> {
   console.log(myString);

--- a/examples/html/README.md
+++ b/examples/html/README.md
@@ -25,7 +25,7 @@ Rollup and then writes out the bundles.
 To view your new HTML page and bundle code run:
 
 ```console
-deno run --allow-net --allow-read https://deno.land/std@0.91.0/http/file_server.ts ./dist --port 3000
+deno run --allow-net --allow-read https://deno.land/std@0.100.0/http/file_server.ts ./dist --port 3000
 ```
 
 This uses the Deno standard library's `file_server` module to serve the static

--- a/examples/image/README.md
+++ b/examples/image/README.md
@@ -25,7 +25,7 @@ Rollup and then writes out the bundles.
 To view your new HTML page and bundle code run:
 
 ```console
-deno run --allow-net --allow-read https://deno.land/std@0.91.0/http/file_server.ts ./dist --port 3000
+deno run --allow-net --allow-read https://deno.land/std@0.100.0/http/file_server.ts ./dist --port 3000
 ```
 
 This uses the Deno standard library's `file_server` module to serve the static

--- a/examples/importmap/import_map.json
+++ b/examples/importmap/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "path/": "https://deno.land/std@0.97.0/path/",
+    "path/": "https://deno.land/std@0.100.0/path/",
     "opine": "https://deno.land/x/opine@1.4.0/mod.ts",
     "message": "./src/message.ts"
   }

--- a/examples/postcss/README.md
+++ b/examples/postcss/README.md
@@ -29,7 +29,7 @@ Rollup and then writes out the bundles.
 To view your new HTML page and bundle code run:
 
 ```console
-deno run --allow-net --allow-read https://deno.land/std@0.91.0/http/file_server.ts ./dist --port 3000
+deno run --allow-net --allow-read https://deno.land/std@0.100.0/http/file_server.ts ./dist --port 3000
 ```
 
 This uses the Deno standard library's `file_server` module to serve the static

--- a/examples/svelte/README.md
+++ b/examples/svelte/README.md
@@ -11,7 +11,7 @@ rollup -c
 To view your new HTML page and bundled code run:
 
 ```console
-deno run --allow-net --allow-read https://deno.land/std@0.91.0/http/file_server.ts ./dist --port 3000
+deno run --allow-net --allow-read https://deno.land/std@0.100.0/http/file_server.ts ./dist --port 3000
 ```
 
 This uses the Deno standard library's `file_server` module to serve the static

--- a/plugins/css/deps.ts
+++ b/plugins/css/deps.ts
@@ -1,1 +1,1 @@
-export { parse } from "https://deno.land/std@0.91.0/path/mod.ts";
+export { parse } from "https://deno.land/std@0.100.0/path/mod.ts";

--- a/plugins/importmap/README.md
+++ b/plugins/importmap/README.md
@@ -10,7 +10,7 @@ Assuming a `import_map.json` exists and contains:
 ```json
 {
   "imports": {
-    "fmt/": "https://deno.land/std@0.91.0/fmt/"
+    "fmt/": "https://deno.land/std@0.100.0/fmt/"
   }
 }
 ```

--- a/plugins/importmap/deps.ts
+++ b/plugins/importmap/deps.ts
@@ -4,4 +4,4 @@ export {
   join,
   normalize,
   relative,
-} from "https://deno.land/std@0.97.0/path/mod.ts";
+} from "https://deno.land/std@0.100.0/path/mod.ts";

--- a/plugins/postcss/deps.ts
+++ b/plugins/postcss/deps.ts
@@ -4,4 +4,4 @@ export type {
 } from "https://deno.land/x/postcss@8.2.6/lib/postcss.d.ts";
 export { default as postcss } from "https://deno.land/x/postcss@8.2.6/mod.js";
 export { default as postcssModules } from "https://esm.sh/postcss-modules@4.0.0";
-export { parse } from "https://deno.land/std@0.91.0/path/mod.ts";
+export { parse } from "https://deno.land/std@0.100.0/path/mod.ts";

--- a/plugins/svelte/deps.ts
+++ b/plugins/svelte/deps.ts
@@ -1,4 +1,4 @@
-export * as path from "https://deno.land/std@0.91.0/path/mod.ts";
+export * as path from "https://deno.land/std@0.100.0/path/mod.ts";
 
 export {
   compile,

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -1,5 +1,5 @@
-export * as posixPath from "https://deno.land/std@0.97.0/path/posix.ts";
-export { createRequire } from "https://deno.land/std@0.97.0/node/module.ts";
+export * as posixPath from "https://deno.land/std@0.100.0/path/posix.ts";
+export { createRequire } from "https://deno.land/std@0.100.0/node/module.ts";
 export { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 export { default as assert } from "https://esm.sh/assert@2.0.0";
 export { default as listGitHub } from "https://esm.sh/list-github-dir-content@3.0.0";


### PR DESCRIPTION
# Issue

Test suite is failing on deno version 1.11.4. 

See: https://github.com/cmorten/deno-rollup/issues/39

## Details

Upgraded to deno std@0.100.0 that it is compatible with deno version 1.11.4 and Test are now passing.

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required).
